### PR TITLE
Topic/tests

### DIFF
--- a/mpc-pointing/src/mpc.cpp
+++ b/mpc-pointing/src/mpc.cpp
@@ -22,7 +22,7 @@ void MPC_Point::initialize(const ConstVectorRef &q0, const ConstVectorRef &v0,
   x0_.resize(designer_.get_rModel().nq + designer_.get_rModel().nv);
   x0_ << shapeState(q0, v0);
   designer_.updateReducedModel(x0_);
-  designer_.updateCompleteModel(q0);
+  // designer_.updateCompleteModel(q0);
 
   // Setup target
   setTarget(toolMtarget);
@@ -34,6 +34,21 @@ void MPC_Point::initialize(const ConstVectorRef &q0, const ConstVectorRef &v0,
 
   initialized_ = true;
 }
+
+// void MPC_Point::initialize(const VectorXd &x0, const SE3 &toolMtarget) {
+//   x0_ = x0;
+//   designer_.updateReducedModel(x0_);
+
+//   // Setup target
+//   setTarget(toolMtarget);
+
+//   // Init OCP
+//   OCP_.initialize(x0_, oMtarget_);
+//   u0_ = OCP_.get_torque();
+//   K0_ = OCP_.get_gain();
+
+//   initialized_ = true;
+// }
 
 void MPC_Point::iterate(const ConstVectorRef &q_current,
                         const ConstVectorRef &v_current,

--- a/mpc-pointing/src/ocp-params.cpp
+++ b/mpc-pointing/src/ocp-params.cpp
@@ -65,10 +65,9 @@ void OCPSettings_Point::readParamsFromYamlString(std::string &StringToParse) {
           sizeWeight += (int)buffer.size();
         }
       } else {
-        std::cout << "No " << nodeName << std::endl;
+        std::cout << "No stateWeights" << std::endl;
       }
     }
-    std::cout << sizeWeight << std::endl;
     aref_stateWeights.resize((Eigen::Index)sizeWeight);
     aref_stateWeights = stateWeights.head(sizeWeight);
   };

--- a/pyTalos/test_sobec.py
+++ b/pyTalos/test_sobec.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #####################
 #  LOADING MODULES  #
 #####################

--- a/pyTalos/test_sobec.py
+++ b/pyTalos/test_sobec.py
@@ -75,8 +75,8 @@ pinWrapper.addEndEffectorFrame(
 # MPC
 MPC = MPC_Point(MPCparams, OCPparams, pinWrapper)
 MPC.initialize(
-    pinWrapper.get_rModel().referenceConfigurations["half_sitting"],
-    pinWrapper.get_v0(),
+    pinWrapper.get_rModelComplete().referenceConfigurations["half_sitting"],
+    pinWrapper.get_v0Complete(),
     pin.SE3.Identity(),
 )
 

--- a/ros-interface/CMakeLists.txt
+++ b/ros-interface/CMakeLists.txt
@@ -76,6 +76,11 @@ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 add_executable(ros_mpc_pointing src/ros-mpc-pointing.cpp)
 target_link_libraries(ros_mpc_pointing ${PROJECT_NAME} mpc-pointing sobec::sobec Eigen3::Eigen ${catkin_LIBRARIES})
 
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/ros-mpc-test.test)
+endif()
+
 # Installation
 install(
   TARGETS ${PROJECT_NAME}
@@ -85,6 +90,7 @@ install(TARGETS ros_mpc_pointing RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY ../config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY test DESTINATION share/${PROJECT_NAME})
   
   
 

--- a/ros-interface/include/ros-interface/ros-mpc-interface.h
+++ b/ros-interface/include/ros-interface/ros-mpc-interface.h
@@ -15,32 +15,30 @@
 
 class ROS_MPC_Interface {
  public:
-  ROS_MPC_Interface();
-  void load(ros::NodeHandle nh);
+  ROS_MPC_Interface(ros::NodeHandle nh);
   void update(const Eigen::VectorXd& u0, const Eigen::MatrixXd& K0);
 
   Eigen::VectorXd& get_robotState();
 
  private:
   void SensorCb(const linear_feedback_controller_msgs::SensorConstPtr& msg);
-  void mapEigenToTF(const Eigen::VectorXd& u0, const Eigen::MatrixXd& K0);
+  void mapMsgToJointSates();
+  void mapControlToMsg(const Eigen::VectorXd& u0, const Eigen::MatrixXd& K0);
 
   ros::Subscriber sensor_sub_;
   boost::shared_ptr<realtime_tools::RealtimePublisher<
       linear_feedback_controller_msgs::Control>>
       command_pub_;
 
+  // Ros messages
   linear_feedback_controller_msgs::Sensor sensor_msg_;
   linear_feedback_controller_msgs::Control control_msg_;
 
-  linear_feedback_controller_msgs::Eigen::Sensor sensor_eigen_;
+  // Robot state (with joints)
   Eigen::VectorXd jointStates_;
 
   // prealocated memory
-
-  Eigen::VectorXd jointPos_, jointVel_;
-  Eigen::Vector3d base_position_, base_linear_vel_, base_angular_vel_;
-  Eigen::Quaterniond base_quaternion_;
+  linear_feedback_controller_msgs::Eigen::Sensor sensor_eigen_;
 };
 
 #endif  // ROS_MPC_INTERFACE

--- a/ros-interface/package.xml
+++ b/ros-interface/package.xml
@@ -17,6 +17,7 @@
   <depend>linear_feedback_controller_msgs</depend>
   <depend>mpc-pointing</depend>
 
+  <build_depend>rostest</build_depend>
 
   <export>
 

--- a/ros-interface/test/ros-mpc-test.test
+++ b/ros-interface/test/ros-mpc-test.test
@@ -1,0 +1,7 @@
+<launch>
+    <!-- <include file="$(find ros-interface)/launch/ros-mpc-basic.launch"/>
+    <test test-name="controlled_joints_nonempty" pkg="rostest" type="paramtest" name="paramtest_nonempty">
+        <param name="param_name_target" value="/controlled_joints" />
+    </test> -->
+    <test test-name="test_mpc_interface" pkg="ros-interface" type="$(find ros-interface)/test/test_mpc_interface.py"/>
+</launch>

--- a/ros-interface/test/ros-mpc-test.test
+++ b/ros-interface/test/ros-mpc-test.test
@@ -1,7 +1,11 @@
 <launch>
-    <!-- <include file="$(find ros-interface)/launch/ros-mpc-basic.launch"/>
-    <test test-name="controlled_joints_nonempty" pkg="rostest" type="paramtest" name="paramtest_nonempty">
+    <include file="$(find ros-interface)/launch/ros-mpc-basic.launch"/>
+    <!-- <test test-name="controlled_joints_nonempty" pkg="rostest" type="paramtest" name="paramtest_nonempty">
         <param name="param_name_target" value="/controlled_joints" />
     </test> -->
-    <test test-name="test_mpc_interface" pkg="ros-interface" type="$(find ros-interface)/test/test_mpc_interface.py"/>
+    <test test-name="ROSInterfaceBasic" 
+        pkg="ros-interface"
+        type="test_mpc_interface.py"
+        time-limit="100.0"
+        required="true"/>
 </launch>

--- a/ros-interface/test/test_mpc_interface.py
+++ b/ros-interface/test/test_mpc_interface.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import sys
+import unittest
+
+import rospy
+from linear__feedback_controller_msgs import Control, Sensor
+
+PKG = "ros-interface"
+NAME = "MPC_Interface_test"
+
+
+class TestMPCInterface(unittest.TestCase):
+    # def __init__(self, *args):
+    #     super(TestMPCInterface, self).__init__(*args)
+
+    #     self.sensorData = Sensor
+
+    # test 1 == 1
+    def test_one_equals_one(self):
+        rospy.loginfo("-D- test_one_equals_one")
+        self.assertEquals(1, 1, "1!=1")
+
+    # def test_message_reception(self):
+    #     rospy.init_node(NAME, anonymous=True)
+    #     pub = rospy.Publisher("/sensor_state", Sensor)
+    #     pub.publish(self.sensorData)
+    #     msg = rospy.wait_for_message("command", Control)
+    #     assert (
+    #         msg.InitialState == self.sensorData
+    #     ), "Received initial state should be equal to the one sent"
+    #     self.success = True
+
+
+if __name__ == "__main__":
+    import rostest
+    rostest.rosrun(PKG, NAME, TestMPCInterface)

--- a/ros-interface/test/test_mpc_interface.py
+++ b/ros-interface/test/test_mpc_interface.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
-import sys
+# import sys
 import unittest
-
 import rospy
-from linear__feedback_controller_msgs import Control, Sensor
+import numpy as np
+from std_msgs.msg import Header
+from linear_feedback_controller_msgs.msg import Sensor, Control
+from geometry_msgs.msg import Pose, Twist, Point, Quaternion, Vector3
+from sensor_msgs.msg import JointState
+from time import sleep
 
 PKG = "ros-interface"
 NAME = "MPC_Interface_test"
@@ -14,24 +18,71 @@ class TestMPCInterface(unittest.TestCase):
     # def __init__(self, *args):
     #     super(TestMPCInterface, self).__init__(*args)
 
-    #     self.sensorData = Sensor
-
     # test 1 == 1
     def test_one_equals_one(self):
         rospy.loginfo("-D- test_one_equals_one")
         self.assertEquals(1, 1, "1!=1")
 
-    # def test_message_reception(self):
-    #     rospy.init_node(NAME, anonymous=True)
-    #     pub = rospy.Publisher("/sensor_state", Sensor)
-    #     pub.publish(self.sensorData)
-    #     msg = rospy.wait_for_message("command", Control)
-    #     assert (
-    #         msg.InitialState == self.sensorData
-    #     ), "Received initial state should be equal to the one sent"
-    #     self.success = True
+    def test_message_reception(self):
+        rospy.init_node(NAME, anonymous=True)
+
+        self.sensorData = self._define_sensor_msg()
+
+        pub = rospy.Publisher("sensor_state", Sensor)
+        pub.publish(self.sensorData)
+
+        msg = rospy.wait_for_message("command", Control, timeout=10)
+        self.assertEquals(
+            msg.InitialState,
+            self.sensorData,
+            "Received initial state should be equal to the one sent",
+        )
+
+    def _define_sensor_msg(self):
+        controlled_joints = rospy.get_param("controlled_joints")
+
+        sensorData = Sensor(
+            base_pose=Pose(
+                position=Point(x=0, y=0, z=0),
+                orientation=Quaternion(x=0, y=0, z=0, w=1),
+            ),
+            base_twist=Twist(
+                linear=Vector3(x=0, y=0, z=0), angular=Vector3(x=0, y=0, z=0)
+            ),
+            joint_state=JointState(
+                name=controlled_joints,
+                position=np.zeros(len(controlled_joints)),
+                velocity=np.zeros(len(controlled_joints)),
+            ),
+        )
+
+        return sensorData
 
 
 if __name__ == "__main__":
-    import rostest
-    rostest.rosrun(PKG, NAME, TestMPCInterface)
+    # import rostest
+    # rostest.rosrun(PKG, NAME, TestMPCInterface)
+
+    rospy.init_node(NAME, anonymous=True)
+
+    controlled_joints = rospy.get_param("controlled_joints")
+
+    sensorData = Sensor(
+        header=Header(stamp=rospy.get_rostime()),
+        base_pose=Pose(
+            position=Point(x=0, y=0, z=0),
+            orientation=Quaternion(x=0, y=0, z=0, w=1),
+        ),
+        base_twist=Twist(linear=Vector3(x=0, y=0, z=0), angular=Vector3(x=0, y=0, z=0)),
+        joint_state=JointState(
+            name=controlled_joints,
+            position=np.ones(len(controlled_joints)),
+            velocity=np.zeros(len(controlled_joints)),
+        ),
+    )
+
+    pub = rospy.Publisher("sensor_state", Sensor, queue_size=10)
+    for _ in range(10):
+        print("Publishing empty sensor state")
+        pub.publish(sensorData)
+        sleep(1)

--- a/ros-interface/test/test_mpc_interface.py
+++ b/ros-interface/test/test_mpc_interface.py
@@ -15,35 +15,35 @@ NAME = "MPC_Interface_test"
 
 
 class TestMPCInterface(unittest.TestCase):
-    # def __init__(self, *args):
-    #     super(TestMPCInterface, self).__init__(*args)
-
-    # test 1 == 1
-    def test_one_equals_one(self):
-        rospy.loginfo("-D- test_one_equals_one")
-        self.assertEquals(1, 1, "1!=1")
-
     def test_message_reception(self):
         rospy.init_node(NAME, anonymous=True)
 
-        self.sensorData = self._define_sensor_msg()
+        self.sensorMsg = self._define_sensor_msg()
 
-        pub = rospy.Publisher("sensor_state", Sensor)
-        pub.publish(self.sensorData)
+        pub = rospy.Publisher("sensor_state", Sensor, queue_size=10)
+        for _ in range(5):
+            pub.publish(self.sensorMsg)
+            sleep(1)
 
-        msg = rospy.wait_for_message("command", Control, timeout=10)
+        msg = rospy.wait_for_message("command", Control, timeout=30)
         self.assertEquals(
-            msg.InitialState,
-            self.sensorData,
-            "Received initial state should be equal to the one sent",
+            msg.initial_state.base_pose,
+            self.sensorMsg.base_pose,
+            "Base pose in received initial state does not match the one sent to the robot",
+        )
+        self.assertEquals(
+            msg.initial_state.base_twist,
+            self.sensorMsg.base_twist,
+            "Base twist in received initial state does not match the one sent to the robot",
         )
 
     def _define_sensor_msg(self):
         controlled_joints = rospy.get_param("controlled_joints")
 
         sensorData = Sensor(
+            header=Header(stamp=rospy.get_rostime()),
             base_pose=Pose(
-                position=Point(x=0, y=0, z=0),
+                position=Point(x=0, y=0, z=1.01927),
                 orientation=Quaternion(x=0, y=0, z=0, w=1),
             ),
             base_twist=Twist(
@@ -51,8 +51,36 @@ class TestMPCInterface(unittest.TestCase):
             ),
             joint_state=JointState(
                 name=controlled_joints,
-                position=np.zeros(len(controlled_joints)),
-                velocity=np.zeros(len(controlled_joints)),
+                position=np.array(
+                    [
+                        0,
+                        0,
+                        -0.411354,
+                        0.859395,
+                        -0.448041,
+                        -0.00170800,
+                        0,
+                        0,
+                        -0.411354,
+                        0.859395,
+                        -0.448041,
+                        -0.00170800,
+                        0,
+                        0.00676100,
+                        0.258470,
+                        0.173046,
+                        -0.0002,
+                        -0.525366,
+                        0,
+                        0,
+                        0.1,
+                        -0.25847,
+                        -0.173046,
+                        0.0002,
+                        -0.525366,
+                    ]
+                ),
+                velocity=np.zeros(len(controlled_joints) - 1),
             ),
         )
 
@@ -60,29 +88,71 @@ class TestMPCInterface(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # import rostest
-    # rostest.rosrun(PKG, NAME, TestMPCInterface)
+    import rostest
+    rostest.rosrun(PKG, NAME, TestMPCInterface)
 
     rospy.init_node(NAME, anonymous=True)
 
-    controlled_joints = rospy.get_param("controlled_joints")
+    # controlled_joints = rospy.get_param("controlled_joints")
 
-    sensorData = Sensor(
-        header=Header(stamp=rospy.get_rostime()),
-        base_pose=Pose(
-            position=Point(x=0, y=0, z=0),
-            orientation=Quaternion(x=0, y=0, z=0, w=1),
-        ),
-        base_twist=Twist(linear=Vector3(x=0, y=0, z=0), angular=Vector3(x=0, y=0, z=0)),
-        joint_state=JointState(
-            name=controlled_joints,
-            position=np.ones(len(controlled_joints)),
-            velocity=np.zeros(len(controlled_joints)),
-        ),
-    )
+    # sensorData = Sensor(
+    #     header=Header(stamp=rospy.get_rostime()),
+    #     base_pose=Pose(
+    #         position=Point(x=0, y=0, z=1.01927),
+    #         orientation=Quaternion(x=0, y=0, z=0, w=1),
+    #     ),
+    #     base_twist=Twist(linear=Vector3(x=0, y=0, z=0), angular=Vector3(x=0, y=0, z=0)),
+    #     joint_state=JointState(
+    #         name=controlled_joints,
+    #         position=np.array(
+    #             [
+    #                 0,
+    #                 0,
+    #                 -0.411354,
+    #                 0.859395,
+    #                 -0.448041,
+    #                 -0.00170800,
+    #                 0,
+    #                 0,
+    #                 -0.411354,
+    #                 0.859395,
+    #                 -0.448041,
+    #                 -0.00170800,
+    #                 0,
+    #                 0.00676100,
+    #                 0.258470,
+    #                 0.173046,
+    #                 -0.0002,
+    #                 -0.525366,
+    #                 0,
+    #                 0,
+    #                 0.1,
+    #                 -0.25847,
+    #                 -0.173046,
+    #                 0.0002,
+    #                 -0.525366,
+    #             ]
+    #         ),
+    #         velocity=np.zeros(len(controlled_joints) - 1),
+    #     ),
+    # )
 
-    pub = rospy.Publisher("sensor_state", Sensor, queue_size=10)
-    for _ in range(10):
-        print("Publishing empty sensor state")
-        pub.publish(sensorData)
-        sleep(1)
+    # pub = rospy.Publisher("sensor_state", Sensor, queue_size=10)
+    # for _ in range(2):
+    #     print("Publishing empty sensor state")
+    #     pub.publish(sensorData)
+    #     sleep(1)
+
+    # print("Waiting for command")
+    # msg = rospy.wait_for_message("command", Control, timeout=30)
+    # assert (
+    #     msg.initial_state.base_pose == sensorData.base_pose
+    #     and msg.initial_state.base_twist == sensorData.base_twist
+    # ), "Initial state of received message doesn't match the state sent by the robot"
+
+    # assert (
+    #     msg.initial_state.joint_state.name.all() == sensorData.joint_state.name.all()
+    # ), "Intial joint state error"
+
+    # print(msg.initial_state)
+    # print(sensorData)


### PR DESCRIPTION
Add integrative test for Ros-interface and MPC.
The last commit passes the newly created test.

For now the test is not integrated in a .test file and has to be launched by hand:
A test node is created that sends a default sensor message to the MPC and checks if the Controller sends back a command message of the right shape.