### PR TITLE
submodule: use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git@github.com:jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Hi,

HTTPS is a more sensible default protocol, because it is always available and never require authentication on public repos, and is therefore better suited for automation.

If you prefer SSH when working on your local computer, you can add this to your `~/.gitconfig`:
```
[url "git@github.com:"]
	insteadOf = https://github.com/